### PR TITLE
ci: add manual workflow to create and push release tags

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,67 @@
+name: Create Release Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number to release (e.g. 1.2.3, without a "v" prefix)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: create-release-tag
+
+jobs:
+  # TEMPORARY: tags/pushes against whichever branch triggered the run, since
+  # main currently has unresolved conflicts. Re-add a main-only guard (see git
+  # history) once main is caught up and this should only cut releases from main.
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::'$VERSION' is not a valid semver version (expected format: X.Y.Z or X.Y.Z-prerelease)."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag does not already exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag '$VERSION' already exists."
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Bump package.json version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: npm pkg set version="$VERSION"
+
+      - name: Commit and tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: release $VERSION"
+          git tag "$VERSION"
+          git push origin "HEAD:${{ github.ref_name }}"
+          git push origin "refs/tags/$VERSION"


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` GitHub Action ([.github/workflows/create-release-tag.yml](.github/workflows/create-release-tag.yml)) that takes a `version` input, validates it as semver, bumps `package.json`'s version, and creates + pushes a matching git tag (bare, e.g. `0.2.4`).
- Net-new file only, no other changes — pushed directly off current `main` to avoid the pending conflicts on `feat/android-16-kb`.
- Currently targets whichever branch triggers the run (not hardcoded to `main`), since `main` needs to be caught up first. Should be tightened to a `main`-only guard once that's done.

## Test plan
- [ ] Merge to main
- [ ] Run via Actions tab → "Create Release Tag" → confirm dropdown appears
- [ ] Trigger with a test version against a throwaway branch, confirm tag + commit are created and pushed