### PR TITLE
ci: rename release workflow and job

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,4 +1,4 @@
-name: Create Release Tag
+name: Release Version
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ jobs:
   # TEMPORARY: tags/pushes against whichever branch triggered the run, since
   # main currently has unresolved conflicts. Re-add a main-only guard (see git
   # history) once main is caught up and this should only cut releases from main.
-  tag:
+  Release:
     runs-on: ubuntu-latest
     steps:
       - name: Validate version input


### PR DESCRIPTION
## Summary
- Renames the workflow display name from "Create Release Tag" to "Release Version"
- Renames the job id from `tag` to `Release`

## Test plan
- [ ] Merge to main
- [ ] Confirm Actions tab shows "Release Version" and the job is labeled "Release"